### PR TITLE
arb-deploy dev mode

### DIFF
--- a/arb-deploy
+++ b/arb-deploy
@@ -27,8 +27,8 @@ services:
     arb-ethbridge:
         image: arb-ethbridge
         build:
-#           context: https://github.com/OffchainLabs/arb-ethbridge.git#alpha
-            context: ./compose/arb-ethbridge
+#           context: https://github.com/OffchainLabs/arb-ethbridge.git#v0.1.0
+            context: %s
             args:
                 MNEMONIC: '%s'
                 NUM_WALLETS: %d
@@ -50,21 +50,23 @@ services:
             - %s:/home/user/contract.ao
         image: arb-validator
         build:
-#           context: https://github.com/OffchainLabs/arb-validator.git#alpha
-            context: ./compose/arb-validator
+#           context: https://github.com/OffchainLabs/arb-validator.git#v0.1.0
+            context: %s
             args:
                 WAIT_FOR: 'arb-ethbridge:17545'
                 ETH_URL: 'ws://arb-ethbridge:7545'
+                DEBUG: %d
                 ID: 0
         ports:
             - '1235:1235'
             - '1236:1236'
 """)
 
-def compose_header(mnemonic, num_wallets, num_validators, gas_per_wallet, gas_limit, verbose,
-    state_abspath, contract_abspath):
-    return (COMPOSE_HEADER % (mnemonic, num_wallets, num_validators, gas_per_wallet,
-        gas_limit, verbose, state_abspath, contract_abspath))
+def compose_header(cethbridge, mnemonic, num_wallets, num_validators, gas_per_wallet,
+                   gas_limit, verbose, state_abspath, contract_abspath, cvalidator, d):
+    return (COMPOSE_HEADER % (cethbridge, mnemonic, num_wallets, num_validators,
+                              gas_per_wallet, gas_limit, verbose, state_abspath,
+                              contract_abspath, cvalidator, int(d)))
 
 # Parameters: validator id, absolute path to state folder,
 # absolute path to contract, validator id
@@ -96,12 +98,14 @@ def compose_validator(validator_id, state_abspath, contract_abspath):
 
 # Compile contracts to `contract.ao` and export to Docker and run validators
 def deploy(contract_name, n_validators, mnemonic, verbose, gas_per_wallet,
-    gas_limit):
-    # Check for compose folder and get dependencies
-    if not os.path.isdir('compose'):
-        run('mkdir compose')
-        run('git clone https://github.com/OffchainLabs/arb-ethbridge.git ./compose/arb-ethbridge')
-        run('git clone https://github.com/OffchainLabs/arb-validator.git ./compose/arb-validator')
+           gas_limit, dev, s):
+    f = 'compose'
+    if dev:
+        dev_mode(f)
+    # dev-mode context
+    context = 'https://github.com/OffchainLabs/%s.git#v0.1.0'
+    if dev:
+        context = './' + f + '/' + '%s'
 
     # Create VALIDATOR_STATE_DIRNAME s if they don't exist
     states_path = os.path.abspath(VALIDATOR_STATE_DIRNAME)
@@ -112,34 +116,74 @@ def deploy(contract_name, n_validators, mnemonic, verbose, gas_per_wallet,
     # Check for DOCKER_COMPOSE_FILENAME and halt if running
     compose = os.path.abspath('./' + DOCKER_COMPOSE_FILENAME)
     if os.path.isfile(compose):
-        run('sudo docker-compose -f %s down' % compose)
+        run('docker-compose -f %s down' % compose, sudo=s)
+
+    # Check for any running docker containers
+    if subprocess.check_output(('sudo ' if s else '') + 'docker ps -q',
+                               shell=True).decode("utf-8") != '':
+        run('docker ps', sudo=s)
+        y = raw_input('Would you like to kill and remove ALL docker containers? [y/N] ')
+        if str(y).lower().strip() == 'y':
+            run('docker kill $(docker ps -q)', shell=True, sudo=s)
+            run('docker rm $(docker ps -aq)', shell=True, sudo=s)
+
+    # number of wallets
+    n_wallets = n_validators + 100
 
     # Overwrite DOCKER_COMPOSE_FILENAME
     contract = os.path.abspath(contract_name)
     contents = (
         compose_header(
+            context % 'arb-ethbridge',
             mnemonic,
-            max(n_validators, 100),
+            n_wallets,
             n_validators,
             gas_per_wallet,
             gas_limit,
             verbose,
             states_path + str(0),
-            contract
+            contract,
+            context % 'arb-validator',
+            dev,
         ) + ''.join([compose_validator(i, states_path + str(i), contract) for i in range(1, n_validators)]))
     with open(compose, 'w') as f:
         f.write(contents)
 
     # Build and run
-    run('sudo docker-compose -f %s build' % compose)
-    run('sudo docker-compose -f %s up' % compose)
+    run('docker-compose -f %s build' % compose, sudo=s)
+    run('docker-compose -f %s up' % compose, sudo=s)
+
+# Check for compose folder `f` and get dependencies
+def dev_mode(f):
+    if not os.path.isdir(f):
+        GC = 'git clone https://github.com/OffchainLabs/%s.git ./' + f + '/%s'
+        run('mkdir ' + f)
+        run(GC % ('arb-ethbridge', 'arb-ethbridge'))
+        run(GC % ('arb-validator', 'arb-validator'))
+        run(GC % ('arb-avm', 'arb-validator/arb-avm'))
+        run('ln -sf arb-validator/arb-avm ' + f + '/arb-avm')
+        y = str(raw_input('Link all providers locally? [Y/n] ')).lower().strip()
+        if y == 'y' or y == '':
+            run(GC % ('arb-web3-provider', 'arb-web3-provider'))
+            run(GC % ('arb-ethers-provider', 'arb-ethers-provider'))
+            run(GC % ('arb-truffle-provider', 'arb-truffle-provider'))
+            symlink = 'rm -rf node_modules/%s && ln -sf ../' + f + '/%s node_modules/%s'
+            link = lambda x: symlink % (x, x, x)
+            run(link('arb-web3-provider'), shell=True)
+            run(link('arb-ethers-provider'), shell=True)
+            run(link('arb-truffle-provider'), shell=True)
 
 # Run commands in shell
-def run(command):
+def run(command, shell=False, sudo=False):
     BOLD='\033[1m'
     END='\033[0m'
+    if sudo:
+        command = 'sudo ' + command
     print(BOLD + '$ %s\n' % command + END)
-    subprocess.call(command.split())
+    if shell:
+        os.system(command)
+    else:
+        subprocess.call(command.split())
 
 ### ----------------------------------------------------------------------------
 ### Command line interface
@@ -155,6 +199,10 @@ def main():
     parser.add_argument('n_validators', type=int,
         help='The number of validators to deploy.')
     # Optional
+    parser.add_argument('-d', '--dev', action='store_true', dest='dev',
+        help='Downloads dependencies into `compose` folder if not created yet')
+    parser.add_argument('-s', '--sudo', action='store_true', dest='sudo',
+        help='Run docker-compose with sudo. May be helpful for some platforms')
     parser.add_argument('-l', '--gasLimit', type=int,
         dest='gas_limit', default=6721975,
         help='The block gas limit in wei [ganache-cli parameter]')
@@ -181,7 +229,7 @@ def main():
 
     # Deploy
     deploy(args.contract, args.n_validators, args.mnemonic, verboseFlag,
-        args.gas_per_wallet, args.gas_limit)
+           args.gas_per_wallet, args.gas_limit, args.dev, args.sudo)
 
 if __name__ == '__main__':
     try:

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "lite-server": "^2.5.2"
   },
   "dependencies": {
-    "arb-truffle-provider": "https://github.com/OffchainLabs/arb-truffle-provider.git",
-    "arb-web3-provider": "https://github.com/OffchainLabs/arb-ethers-provider.git"
+    "arb-truffle-provider": "https://github.com/OffchainLabs/arb-truffle-provider.git"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,19 +2,6 @@
 # yarn lockfile v1
 
 
-"@types/node@^10.3.2", "@types/node@^10.3.5":
-  version "10.14.8"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.8.tgz#fe444203ecef1162348cd6deb76c62477b2cc6e9"
-  integrity sha512-I4+DbJEhLEg4/vIy/2gkWDvXBOOtPKV9EnLhYjMoqxcRW+TTZtUftkHktz/a8suoD5mUL7m6ReLrkPvSsCQQmw==
-
-JSONStream@^1.3.1:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
-  integrity sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==
-  dependencies:
-    jsonparse "^1.2.0"
-    through ">=2.2.7 <3"
-
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -55,11 +42,6 @@ accepts@~1.3.4, accepts@~1.3.5:
   dependencies:
     mime-types "~2.1.24"
     negotiator "0.6.2"
-
-aes-js@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-3.0.0.tgz#e21df10ad6c2053295bcbb8dab40b09dbea87e4d"
-  integrity sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=
 
 aes-js@^3.1.1:
   version "3.1.2"
@@ -120,15 +102,6 @@ aproba@^1.0.3:
   dependencies:
     callsite "^1.0.0"
     ganache-core "^2.5.3"
-
-"arb-web3-provider@https://github.com/OffchainLabs/arb-ethers-provider.git":
-  version "1.0.0"
-  resolved "https://github.com/OffchainLabs/arb-ethers-provider.git#0d23a0fd18273d16d7c2d9e74588306c1ba7c0e5"
-  dependencies:
-    ethers "^4.0.28"
-    jayson "^2.1.2"
-    node-fetch "^2.3.0"
-    promise-poller "^1.7.0"
 
 are-we-there-yet@~1.1.2:
   version "1.1.5"
@@ -913,11 +886,6 @@ bluebird@^3.5.0:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.4.tgz#d6cc661595de30d5b3af5fcedd3c0b3ef6ec5714"
   integrity sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==
 
-bluebird@^3.5.3:
-  version "3.5.5"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.5.tgz#a8d0afd73251effbbd5fe384a77d73003c17a71f"
-  integrity sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==
-
 bn.js@4.11.6:
   version "4.11.6"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.6.tgz#53344adb14617a13f6e8dd2ce28905d1c0ba3215"
@@ -1362,7 +1330,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.12.2, commander@^2.2.0, commander@^2.8.1:
+commander@^2.2.0, commander@^2.8.1:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
@@ -1572,13 +1540,6 @@ debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
-  dependencies:
-    ms "^2.1.1"
-
-debug@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
-  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
 
@@ -1816,16 +1777,6 @@ electron-to-chromium@^1.3.47:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.134.tgz#550222bddac43c6bd6c445c3543a0fe8a615021d"
   integrity sha512-C3uK2SrtWg/gSWaluLHWSHjyebVZCe4ZC0NVgTAoTq8tCR9FareRK5T7R7AS/nPZShtlEcjVMX1kQ8wi4nU68w==
 
-elliptic@6.3.3:
-  version "6.3.3"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.3.3.tgz#5482d9646d54bcb89fd7d994fc9e2e9568876e3f"
-  integrity sha1-VILZZG1UvLif19mU/J4ulWiHbj8=
-  dependencies:
-    bn.js "^4.4.0"
-    brorand "^1.0.1"
-    hash.js "^1.0.0"
-    inherits "^2.0.1"
-
 elliptic@^6.0.0, elliptic@^6.4.0, elliptic@^6.4.1:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.4.1.tgz#c2d0b7776911b86722c632c3c06c60f2f819939a"
@@ -1960,18 +1911,6 @@ es-to-primitive@^1.2.0:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
-
-es6-promise@^4.0.3:
-  version "4.2.6"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.6.tgz#b685edd8258886365ea62b57d30de28fadcd974f"
-  integrity sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q==
-
-es6-promisify@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
-  integrity sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=
-  dependencies:
-    es6-promise "^4.0.3"
 
 escape-html@~1.0.3:
   version "1.0.3"
@@ -2251,22 +2190,6 @@ ethereumjs-wallet@0.6.2:
     utf8 "^3.0.0"
     uuid "^3.3.2"
 
-ethers@^4.0.28:
-  version "4.0.28"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.28.tgz#74d9acb57f4ede3337c8d60476b38d0fe646af01"
-  integrity sha512-5JTHrPoFLqf+xCAI3pKwXSOgWBSJJoAUdPtPLr1ZlKbSKiIFMkPlRNovmZS3jhIw5sHW1YoVWOaJ6ZR2gKRbwg==
-  dependencies:
-    "@types/node" "^10.3.2"
-    aes-js "3.0.0"
-    bn.js "^4.4.0"
-    elliptic "6.3.3"
-    hash.js "1.1.3"
-    js-sha3 "0.5.7"
-    scrypt-js "2.0.4"
-    setimmediate "1.0.4"
-    uuid "2.0.1"
-    xmlhttprequest "1.8.0"
-
 ethjs-unit@0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/ethjs-unit/-/ethjs-unit-0.1.6.tgz#c665921e476e87bce2a9d588a6fe0405b2c41699"
@@ -2398,11 +2321,6 @@ extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
-
-eyes@^0.1.8:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
-  integrity sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=
 
 fake-merkle-patricia-tree@^1.0.1:
   version "1.0.1"
@@ -2863,14 +2781,6 @@ hash-base@^3.0.0:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-hash.js@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.3.tgz#340dedbe6290187151c1ea1d777a3448935df846"
-  integrity sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==
-  dependencies:
-    inherits "^2.0.3"
-    minimalistic-assert "^1.0.0"
-
 hash.js@^1.0.0, hash.js@^1.0.3:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
@@ -3292,25 +3202,6 @@ isurl@^1.0.0-alpha5:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
 
-jayson@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/jayson/-/jayson-2.1.2.tgz#3612f578529b5cc84301f098f29cd1612119e53d"
-  integrity sha512-2GejcQnEV35KYTXoBvzALIDdO/1oyEIoJHBnaJFhJhcurv0x2JqUXQW6xlDUhcNOpN9t+d2w+JGA6vOphb+5mg==
-  dependencies:
-    "@types/node" "^10.3.5"
-    JSONStream "^1.3.1"
-    commander "^2.12.2"
-    es6-promisify "^5.0.0"
-    eyes "^0.1.8"
-    json-stringify-safe "^5.0.1"
-    lodash "^4.17.11"
-    uuid "^3.2.1"
-
-js-sha3@0.5.7:
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.5.7.tgz#0d4ffd8002d5333aabaf4a23eed2f6374c9f28e7"
-  integrity sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=
-
 js-sha3@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.6.1.tgz#5b89f77a7477679877f58c4a075240934b1f95c0"
@@ -3382,7 +3273,7 @@ json-stable-stringify@^1.0.1:
   dependencies:
     jsonify "~0.0.0"
 
-json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
+json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
@@ -3410,11 +3301,6 @@ jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
   integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
-
-jsonparse@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
-  integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
 
 jsprim@^1.2.2:
   version "1.4.1"
@@ -3962,11 +3848,6 @@ node-fetch@2.1.2:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
   integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
 
-node-fetch@^2.3.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
-  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
-
 node-fetch@~1.7.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
@@ -4357,14 +4238,6 @@ process@~0.5.1:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/process/-/process-0.5.2.tgz#1638d8a8e34c2f440a91db95ab9aeb677fc185cf"
   integrity sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=
-
-promise-poller@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/promise-poller/-/promise-poller-1.7.0.tgz#76788d8d9470af6b604c14592a3d7f93f4c393ee"
-  integrity sha512-wY/zfF06bC+DHbjG8ja8YZsJgg2gw2KYHKa3hBJI1slqBTskGcPg4PEX2K7dbKgVtw9G88MXLPePgA8KtZNqpQ==
-  dependencies:
-    bluebird "^3.5.3"
-    debug "^4.1.0"
 
 promise-to-callback@^1.0.0:
   version "1.0.0"
@@ -4831,11 +4704,6 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-scrypt-js@2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-2.0.4.tgz#32f8c5149f0797672e551c07e230f834b6af5f16"
-  integrity sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==
-
 scrypt.js@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/scrypt.js/-/scrypt.js-0.2.0.tgz#af8d1465b71e9990110bedfc593b9479e03a8ada"
@@ -4994,11 +4862,6 @@ set-value@^2.0.0:
     is-extendable "^0.1.1"
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
-
-setimmediate@1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.4.tgz#20e81de622d4a02588ce0c8da8973cbcf1d3138f"
-  integrity sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=
 
 setimmediate@^1.0.5:
   version "1.0.5"
@@ -5494,7 +5357,7 @@ through2@^2.0.3:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
 
-"through@>=2.2.7 <3", through@^2.3.8, through@~2.3.4, through@~2.3.8:
+through@^2.3.8, through@~2.3.4, through@~2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -5738,7 +5601,7 @@ uuid@2.0.1:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.1.tgz#c2a30dedb3e535d72ccf82e343941a50ba8533ac"
   integrity sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=
 
-uuid@^3.2.1, uuid@^3.3.2:
+uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
@@ -6124,11 +5987,6 @@ xmlhttprequest-ssl@~1.5.4:
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz#c2876b06168aadc40e57d97e81191ac8f4398b3e"
   integrity sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=
-
-xmlhttprequest@1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz#67fe075c5c24fef39f9d65f5f7b7fe75171968fc"
-  integrity sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=
 
 xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.1"


### PR DESCRIPTION
- [x] Updated package.json to remove unused provider and ran `yarn`
- [x] Added `--dev` or `-d` flag to create a `compose` folder and locally link `arb-ethbridge`, `arb-validator`, `arb-avm`, and optionally all three providers.
- [x] Pinned non-dev-mode deploys to tag `v0.1.0` for `arb-ethbridge` and `arb-validator`
- [x] Added `--sudo` or `-s` flag to run all `docker` and `docker-compose` commands with sudo