### PR TITLE
arb-deploy dev-mode improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
-node_modules
-validator-states
+*.ao
 .DS_Store
 arb-docker-compose.yml
 build
-compose
-*.ao
 compiled.json
+compose
+node_modules
+validator-states

--- a/arb-deploy
+++ b/arb-deploy
@@ -186,9 +186,8 @@ def deploy(contract_name, n_validators, mnemonic, verbose, gas_per_wallet,
     if dev_flag or os.path.isdir(DEPLOY_DIR):
         run('cd %s/arb-validator && go mod vendor' % DEPLOY_DIR)
 
-    # Build and stop if exit code is not zero
-    if run('docker-compose -f %s build' % compose, sudo=sudo_flag) != 0:
-        sys.exit(1)
+    # Build
+    run('docker-compose -f %s build' % compose, sudo=sudo_flag)
 
     # Run
     if not build_flag:
@@ -242,7 +241,8 @@ def run(command, sudo=False):
     if sudo:
         command = 'sudo ' + command
     print(BOLD + '$ %s\n' % command + END)
-    return os.system(command)
+    if os.system(command) != 0:
+        sys.exit(1)
 
 ### ----------------------------------------------------------------------------
 ### Command line interface

--- a/arb-deploy
+++ b/arb-deploy
@@ -145,8 +145,8 @@ def deploy(contract_name, n_validators, mnemonic, verbose, gas_per_wallet,
     # Kill and rm all docker containers and images created by any `arb-deploy`
     ps = 'docker ps | grep "arb-validator\|arb-ethbridge" | awk "{ print $1 }"'
     if subprocess.check_output(sudo_cmd + ps, shell=True).decode("utf-8") != '':
-        run(sudo_cmd + 'docker kill $(' + sudo_cmd + ps + ')')
-        run(sudo_cmd + 'docker rm $(' + sudo_cmd + ps + ')')
+        run(sudo_cmd + 'docker kill $(' + sudo_cmd + ps + ')', shell=True)
+        run(sudo_cmd + 'docker rm $(' + sudo_cmd + ps + ')', shell=True)
 
     # number of wallets
     n_wallets = n_validators + 100

--- a/arb-deploy
+++ b/arb-deploy
@@ -231,15 +231,23 @@ def install_dev_mode():
     add_commit_hook(DEPLOY_DIR + '/arb-validator')
     add_commit_hook(DEPLOY_DIR + '/arb-avm')
     # Link providers locally
-    run(GC % ('arb-web3-provider', 'arb-web3-provider'))
-    run(GC % ('arb-ethers-provider', 'arb-ethers-provider'))
     run(GC % ('arb-truffle-provider', 'arb-truffle-provider'))
+    run(GC % ('arb-ethers-provider', 'arb-ethers-provider'))
+    run(GC % ('arb-web3-provider', 'arb-web3-provider'))
+    run('yarn --cwd ' + DEPLOY_DIR + '/arb-truffle-provider')
+    run('yarn --cwd ' + DEPLOY_DIR + '/arb-ethers-provider')
+    run('yarn --cwd ' + DEPLOY_DIR + '/arb-web3-provider')
+    # symlink ethers into web3
+    run('rm -rf ' + DEPLOY_DIR + '/arb-web3-provider/node_modules/' +
+        'arb-ethers-provider && ln -sf ../../arb-ethers-provider ' + DEPLOY_DIR +
+        '/arb-web3-provider/node_modules/arb-ethers-provider')
+    # symlink providers into project
     symlink = ('rm -rf node_modules/%s && ln -sf ../' + DEPLOY_DIR +
         '/%s node_modules/%s')
     link = lambda x: symlink % (x, x, x)
-    run(link('arb-web3-provider'))
-    run(link('arb-ethers-provider'))
     run(link('arb-truffle-provider'))
+    run(link('arb-ethers-provider'))
+    run(link('arb-web3-provider'))
 
 # Create special Dockerfile for dev-mode if required
 def dockerfile_dev_mode(dev_flag, name):

--- a/arb-deploy
+++ b/arb-deploy
@@ -144,7 +144,8 @@ def deploy(contract_name, n_validators, mnemonic, verbose, gas_per_wallet,
             sudo=sudo_flag)
     # Kill and rm all docker containers and images created by any `arb-deploy`
     ps = "grep 'arb-validator\|arb-ethbridge' | awk '{ print $1 }'"
-    if subprocess.check_output(sudo_cmd + ps, shell=True).decode("utf-8") != '':
+    if subprocess.check_output(sudo_cmd + 'docker_ps | ' + ps, shell=True
+        ).decode("utf-8") != '':
         run(sudo_cmd + 'docker kill $(' + sudo_cmd + 'docker ps | ' + ps + ')')
         run(sudo_cmd + 'docker rm $(' + sudo_cmd + 'docker ps -a | ' + ps + ')')
 

--- a/arb-deploy
+++ b/arb-deploy
@@ -141,13 +141,15 @@ def deploy(contract_name, n_validators, mnemonic, verbose, gas_per_wallet,
     # Check for DOCKER_COMPOSE_FILENAME and halt if running
     if os.path.isfile('./' + DOCKER_COMPOSE_FILENAME):
         run('docker-compose -f ./%s down -t 0' % DOCKER_COMPOSE_FILENAME,
-            sudo=sudo_flag)
+            sudo=sudo_flag, exit_on_error=False)
     # Kill and rm all docker containers and images created by any `arb-deploy`
     ps = "grep 'arb-validator\|arb-ethbridge' | awk '{ print $1 }'"
     if subprocess.check_output(sudo_cmd + 'docker ps | ' + ps, shell=True
         ).decode("utf-8") != '':
-        run(sudo_cmd + 'docker kill $(' + sudo_cmd + 'docker ps | ' + ps + ')')
-        run(sudo_cmd + 'docker rm $(' + sudo_cmd + 'docker ps -a | ' + ps + ')')
+        run(sudo_cmd + 'docker kill $(' + sudo_cmd + 'docker ps | ' + ps + ')',
+            exit_on_error=False)
+        run(sudo_cmd + 'docker rm $(' + sudo_cmd + 'docker ps -a | ' + ps + ')',
+            exit_on_error=False)
 
     # number of wallets
     n_wallets = n_validators + 100
@@ -235,13 +237,13 @@ def dockerfile_dev_mode(dev_flag, name):
         return 'Dockerfile'
 
 # Run commands in shell
-def run(command, sudo=False):
+def run(command, sudo=False, exit_on_error=True):
     BOLD='\033[1m'
     END='\033[0m'
     if sudo:
         command = 'sudo ' + command
     print(BOLD + '$ %s\n' % command + END)
-    if os.system(command) != 0:
+    if os.system(command) != 0 and exit_on_error:
         sys.exit(1)
 
 ### ----------------------------------------------------------------------------

--- a/arb-deploy
+++ b/arb-deploy
@@ -1,4 +1,19 @@
 #!/usr/bin/env python3
+
+# Copyright 2019, Offchain Labs, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ### ----------------------------------------------------------------------------
 ### arb-deploy
 ### ----------------------------------------------------------------------------

--- a/arb-deploy
+++ b/arb-deploy
@@ -143,10 +143,10 @@ def deploy(contract_name, n_validators, mnemonic, verbose, gas_per_wallet,
         run('docker-compose -f ./%s down -t 0' % DOCKER_COMPOSE_FILENAME,
             sudo=sudo_flag)
     # Kill and rm all docker containers and images created by any `arb-deploy`
-    ps = 'docker ps | grep "arb-validator\|arb-ethbridge" | awk "{ print $1 }"'
+    ps = "grep 'arb-validator\|arb-ethbridge' | awk '{ print $1 }'"
     if subprocess.check_output(sudo_cmd + ps, shell=True).decode("utf-8") != '':
-        run(sudo_cmd + 'docker kill $(' + sudo_cmd + ps + ')', shell=True)
-        run(sudo_cmd + 'docker rm $(' + sudo_cmd + ps + ')', shell=True)
+        run(sudo_cmd + 'docker kill $(' + sudo_cmd + 'docker ps | ' + ps + ')')
+        run(sudo_cmd + 'docker rm $(' + sudo_cmd + 'docker ps -a | ' + ps + ')')
 
     # number of wallets
     n_wallets = n_validators + 100
@@ -220,31 +220,28 @@ def install_dev_mode():
     symlink = ('rm -rf node_modules/%s && ln -sf ../' + DEPLOY_DIR +
         '/%s node_modules/%s')
     link = lambda x: symlink % (x, x, x)
-    run(link('arb-web3-provider'), shell=True)
-    run(link('arb-ethers-provider'), shell=True)
-    run(link('arb-truffle-provider'), shell=True)
+    run(link('arb-web3-provider'))
+    run(link('arb-ethers-provider'))
+    run(link('arb-truffle-provider'))
 
 # Create special Dockerfile for dev-mode if required
 def dockerfile_dev_mode(dev_flag, name):
     SUB = 'awk \'{ sub(/%s/, "%s") }1\' ' + ('%s/arb-validator/Dockerfile > ' +
         '%s/arb-validator/%s') % (DEPLOY_DIR, DEPLOY_DIR, name)
     if dev_flag or os.path.isdir(DEPLOY_DIR):
-        run(SUB % ('##DEV_', '##DEV_\\n'), shell=True)
+        run(SUB % ('##DEV_', '##DEV_\\n'))
         return name
     else:
         return 'Dockerfile'
 
 # Run commands in shell
-def run(command, shell=False, sudo=False):
+def run(command, sudo=False):
     BOLD='\033[1m'
     END='\033[0m'
     if sudo:
         command = 'sudo ' + command
     print(BOLD + '$ %s\n' % command + END)
-    if shell:
-        return os.system(command)
-    else:
-        return subprocess.call(command.split())
+    return os.system(command)
 
 ### ----------------------------------------------------------------------------
 ### Command line interface

--- a/arb-deploy
+++ b/arb-deploy
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ### ----------------------------------------------------------------------------
 ### arb-deploy
 ### ----------------------------------------------------------------------------
@@ -11,8 +11,14 @@ import sys
 PROG='Arbitrum Deploy'
 __version__ = 'Alpha'
 
+# Version fetched iff DEPLOY_DIR does not exist AND --dev-mode flag not given
+RELEASE_VERSION='v0.1.0'
+
 DOCKER_COMPOSE_FILENAME='arb-docker-compose.yml'
 VALIDATOR_STATE_DIRNAME='validator-states/validator'
+
+# Relative dir name for deployment dependencies
+DEPLOY_DIR='compose'
 
 ### ----------------------------------------------------------------------------
 ### docker-compose template
@@ -52,6 +58,7 @@ services:
         build:
 #           context: https://github.com/OffchainLabs/arb-validator.git#v0.1.0
             context: %s
+            dockerfile: %s
             args:
                 WAIT_FOR: 'arb-ethbridge:17545'
                 ETH_URL: 'ws://arb-ethbridge:7545'
@@ -62,11 +69,12 @@ services:
             - '1236:1236'
 """)
 
-def compose_header(cethbridge, mnemonic, num_wallets, num_validators, gas_per_wallet,
-                   gas_limit, verbose, state_abspath, contract_abspath, cvalidator, d):
+def compose_header(cethbridge, mnemonic, num_wallets, num_validators,
+    gas_per_wallet, gas_limit, verbose, state_abspath, contract_abspath,
+    cvalidator, dockerfile, d):
     return (COMPOSE_HEADER % (cethbridge, mnemonic, num_wallets, num_validators,
                               gas_per_wallet, gas_limit, verbose, state_abspath,
-                              contract_abspath, cvalidator, int(d)))
+                              contract_abspath, cvalidator, dockerfile, int(d)))
 
 # Parameters: validator id, absolute path to state folder,
 # absolute path to contract, validator id
@@ -93,19 +101,36 @@ def compose_validator(validator_id, state_abspath, contract_abspath):
         validator_id))
 
 ### ----------------------------------------------------------------------------
+### .git/hooks/pre-commit
+### ----------------------------------------------------------------------------
+
+GIT_PRE_COMMIT_HOOK=(
+"""
+#!/bin/sh
+
+# Prevent commit if go.mod contains a replace rule
+ERR_MOD="Error: do not commit go.mod without removing all replace rules"
+git grep --cached -q "replace .* => .*" go.mod && echo "${ERR_MOD}" && exit 1 \
+    || true
+
+# Prevent commit if `gofmt -l .` produces any output
+ERR_FMT="Error: please run \`go fmt ./...\` before committing changes"
+gofmt -l $(git diff-index --cached --name-only HEAD | grep ".go") | \
+    grep -q '^' && echo "${ERR_FMT}" && exit 1 || true
+""")
+
+### ----------------------------------------------------------------------------
 ### Deploy
 ### ----------------------------------------------------------------------------
 
 # Compile contracts to `contract.ao` and export to Docker and run validators
 def deploy(contract_name, n_validators, mnemonic, verbose, gas_per_wallet,
-           gas_limit, dev, s):
-    f = 'compose'
-    if dev:
-        dev_mode(f)
-    # dev-mode context
-    context = 'https://github.com/OffchainLabs/%s.git#v0.1.0'
-    if dev:
-        context = './' + f + '/' + '%s'
+           gas_limit, dev_flag, sudo_flag, build_flag):
+    sudo_cmd = 'sudo ' if sudo_flag else ''
+
+    # Install dev_mode if flag set and doesn't exist already
+    if dev_flag and not os.path.isdir(DEPLOY_DIR):
+        install_dev_mode()
 
     # Create VALIDATOR_STATE_DIRNAME s if they don't exist
     states_path = os.path.abspath(VALIDATOR_STATE_DIRNAME)
@@ -114,23 +139,28 @@ def deploy(contract_name, n_validators, mnemonic, verbose, gas_per_wallet,
             os.makedirs(states_path + str(i))
 
     # Check for DOCKER_COMPOSE_FILENAME and halt if running
-    compose = os.path.abspath('./' + DOCKER_COMPOSE_FILENAME)
-    if os.path.isfile(compose):
-        run('docker-compose -f %s down' % compose, sudo=s)
-
-    # Check for any running docker containers
-    if subprocess.check_output(('sudo ' if s else '') + 'docker ps -q',
-                               shell=True).decode("utf-8") != '':
-        run('docker ps', sudo=s)
-        y = raw_input('Would you like to kill and remove ALL docker containers? [y/N] ')
-        if str(y).lower().strip() == 'y':
-            run('docker kill $(docker ps -q)', shell=True, sudo=s)
-            run('docker rm $(docker ps -aq)', shell=True, sudo=s)
+    if os.path.isfile('./' + DOCKER_COMPOSE_FILENAME):
+        run('docker-compose -f ./%s down -t 0' % DOCKER_COMPOSE_FILENAME,
+            sudo=sudo_flag)
+    # Kill and rm all docker containers and images created by any `arb-deploy`
+    ps = 'docker ps | grep "arb-validator\|arb-ethbridge" | awk "{ print $1 }"'
+    if subprocess.check_output(sudo_cmd + ps, shell=True).decode("utf-8") != '':
+        run(sudo_cmd + 'docker kill $(' + sudo_cmd + ps + ')')
+        run(sudo_cmd + 'docker rm $(' + sudo_cmd + ps + ')')
 
     # number of wallets
     n_wallets = n_validators + 100
 
+    # docker-compose build context
+    context = 'https://github.com/OffchainLabs/%s.git#' + RELEASE_VERSION
+    if dev_flag or os.path.isdir(DEPLOY_DIR):
+        context = './' + DEPLOY_DIR + '/' + '%s'
+
+    # dockerfile_dev_mode
+    dockerfile = dockerfile_dev_mode(dev_flag, 'dev-mode.Dockerfile')
+
     # Overwrite DOCKER_COMPOSE_FILENAME
+    compose = os.path.abspath('./' + DOCKER_COMPOSE_FILENAME)
     contract = os.path.abspath(contract_name)
     contents = (
         compose_header(
@@ -144,34 +174,65 @@ def deploy(contract_name, n_validators, mnemonic, verbose, gas_per_wallet,
             states_path + str(0),
             contract,
             context % 'arb-validator',
-            dev,
-        ) + ''.join([compose_validator(i, states_path + str(i), contract) for i in range(1, n_validators)]))
+            dockerfile,
+            dev_flag,
+        ) + ''.join([compose_validator(i, states_path + str(i), contract)
+                        for i in range(1, n_validators)]))
     with open(compose, 'w') as f:
         f.write(contents)
 
-    # Build and run
-    run('docker-compose -f %s build' % compose, sudo=s)
-    run('docker-compose -f %s up' % compose, sudo=s)
+    # Warm build cache
+    if dev_flag or os.path.isdir(DEPLOY_DIR):
+        run('cd %s/arb-validator && go mod vendor' % DEPLOY_DIR)
 
-# Check for compose folder `f` and get dependencies
-def dev_mode(f):
-    if not os.path.isdir(f):
-        GC = 'git clone https://github.com/OffchainLabs/%s.git ./' + f + '/%s'
-        run('mkdir ' + f)
-        run(GC % ('arb-ethbridge', 'arb-ethbridge'))
-        run(GC % ('arb-validator', 'arb-validator'))
-        run(GC % ('arb-avm', 'arb-validator/arb-avm'))
-        run('ln -sf arb-validator/arb-avm ' + f + '/arb-avm')
-        y = str(raw_input('Link all providers locally? [Y/n] ')).lower().strip()
-        if y == 'y' or y == '':
-            run(GC % ('arb-web3-provider', 'arb-web3-provider'))
-            run(GC % ('arb-ethers-provider', 'arb-ethers-provider'))
-            run(GC % ('arb-truffle-provider', 'arb-truffle-provider'))
-            symlink = 'rm -rf node_modules/%s && ln -sf ../' + f + '/%s node_modules/%s'
-            link = lambda x: symlink % (x, x, x)
-            run(link('arb-web3-provider'), shell=True)
-            run(link('arb-ethers-provider'), shell=True)
-            run(link('arb-truffle-provider'), shell=True)
+    # Build and stop if exit code is not zero
+    if run('docker-compose -f %s build' % compose, sudo=sudo_flag) != 0:
+        sys.exit(1)
+
+    # Run
+    if not build_flag:
+        run('docker-compose -f %s up --abort-on-container-exit' % compose,
+            sudo=sudo_flag)
+
+# Istalls arb-ethbridge, arb-validator, arb-avm, arb-web3-provider,
+# arb-ethers-provider, and arb-truffle-provider and link them correctly.
+# Note: arb-avm must be inside arb-validator for Docker. Adds replace rule to
+# go.mod for local development. Also adds pre-commit hook to prevent committing
+# this development rule and does go fmt check
+def install_dev_mode():
+    GC = 'git clone https://github.com/OffchainLabs/%s.git ./' + DEPLOY_DIR + '/%s'
+    run('mkdir ' + DEPLOY_DIR)
+    run(GC % ('arb-ethbridge', 'arb-ethbridge'))
+    run(GC % ('arb-validator', 'arb-validator'))
+    run(GC % ('arb-avm', 'arb-validator/arb-avm'))
+    run('ln -sf arb-validator/arb-avm ' + DEPLOY_DIR + '/arb-avm')
+    # Add git pre-commit hooks to golang repos
+    def add_commit_hook(repo):
+        with open(repo + '/.git/hooks/pre-commit', 'w') as f:
+            f.write(GIT_PRE_COMMIT_HOOK)
+        run('chmod +x ' + repo + '/.git/hooks/pre-commit')
+    add_commit_hook(DEPLOY_DIR + '/arb-validator')
+    add_commit_hook(DEPLOY_DIR + '/arb-avm')
+    # Link providers locally
+    run(GC % ('arb-web3-provider', 'arb-web3-provider'))
+    run(GC % ('arb-ethers-provider', 'arb-ethers-provider'))
+    run(GC % ('arb-truffle-provider', 'arb-truffle-provider'))
+    symlink = ('rm -rf node_modules/%s && ln -sf ../' + DEPLOY_DIR +
+        '/%s node_modules/%s')
+    link = lambda x: symlink % (x, x, x)
+    run(link('arb-web3-provider'), shell=True)
+    run(link('arb-ethers-provider'), shell=True)
+    run(link('arb-truffle-provider'), shell=True)
+
+# Create special Dockerfile for dev-mode if required
+def dockerfile_dev_mode(dev_flag, name):
+    SUB = 'awk \'{ sub(/%s/, "%s") }1\' ' + ('%s/arb-validator/Dockerfile > ' +
+        '%s/arb-validator/%s') % (DEPLOY_DIR, DEPLOY_DIR, name)
+    if dev_flag or os.path.isdir(DEPLOY_DIR):
+        run(SUB % ('##DEV_', '##DEV_\\n'), shell=True)
+        return name
+    else:
+        return 'Dockerfile'
 
 # Run commands in shell
 def run(command, shell=False, sudo=False):
@@ -181,9 +242,9 @@ def run(command, shell=False, sudo=False):
         command = 'sudo ' + command
     print(BOLD + '$ %s\n' % command + END)
     if shell:
-        os.system(command)
+        return os.system(command)
     else:
-        subprocess.call(command.split())
+        return subprocess.call(command.split())
 
 ### ----------------------------------------------------------------------------
 ### Command line interface
@@ -199,10 +260,16 @@ def main():
     parser.add_argument('n_validators', type=int,
         help='The number of validators to deploy.')
     # Optional
-    parser.add_argument('-d', '--dev', action='store_true', dest='dev',
-        help='Downloads dependencies into `compose` folder if not created yet')
+    parser.add_argument('-d', '--dev-mode', action='store_true', dest='dev',
+        help=(('Downloads dependencies into `%s` and links them if `%s` does ' +
+        'not already exist. Note: if `%s` does exist in the current working' +
+        'directory then dev-mode will always be used, even without this flag')
+        % (DEPLOY_DIR, DEPLOY_DIR, DEPLOY_DIR)))
+    parser.add_argument('-b', '--build', action='store_true', dest='build',
+        help='Build only. Do not run')
     parser.add_argument('-s', '--sudo', action='store_true', dest='sudo',
         help='Run docker-compose with sudo. May be helpful for some platforms')
+    # Ganache Options
     parser.add_argument('-l', '--gasLimit', type=int,
         dest='gas_limit', default=6721975,
         help='The block gas limit in wei [ganache-cli parameter]')
@@ -213,6 +280,7 @@ def main():
         default='jar deny prosper gasp flush glass core corn alarm treat leg smart',
         help='Specify the Mnemonic to use (make sure to use "quotes")')
     parser.add_argument('-v', '--verbose', dest='verbose', action='count')
+    # Version
     parser.add_argument('--version', dest='version', action='version',
         version='%(prog)s ' + __version__)
     args = parser.parse_args()
@@ -229,11 +297,10 @@ def main():
 
     # Deploy
     deploy(args.contract, args.n_validators, args.mnemonic, verboseFlag,
-           args.gas_per_wallet, args.gas_limit, args.dev, args.sudo)
+           args.gas_per_wallet, args.gas_limit, args.dev, args.sudo, args.build)
 
 if __name__ == '__main__':
     try:
         main()
     except KeyboardInterrupt:
         sys.exit(1)
-

--- a/arb-deploy
+++ b/arb-deploy
@@ -144,7 +144,7 @@ def deploy(contract_name, n_validators, mnemonic, verbose, gas_per_wallet,
             sudo=sudo_flag)
     # Kill and rm all docker containers and images created by any `arb-deploy`
     ps = "grep 'arb-validator\|arb-ethbridge' | awk '{ print $1 }'"
-    if subprocess.check_output(sudo_cmd + 'docker_ps | ' + ps, shell=True
+    if subprocess.check_output(sudo_cmd + 'docker ps | ' + ps, shell=True
         ).decode("utf-8") != '':
         run(sudo_cmd + 'docker kill $(' + sudo_cmd + 'docker ps | ' + ps + ')')
         run(sudo_cmd + 'docker rm $(' + sudo_cmd + 'docker ps -a | ' + ps + ')')


### PR DESCRIPTION
Changes:
- Runs in `--dev-mode` automatically if `compose` folder exists or flag
- Does not run now if the build fails
- Halt docker-compose immediatley instead of waiting default 10 seconds
- Kills and rms all `arb-validator` and `arb-ethbridge` containers
- Removed all interactive prompts
- Warms arb-validator build cache in dev-mode by running `go mod vendor` on host
- Builds arb-validator dev-mode.Dockerfile by replacing all `##DEV_` with ` `
- Added pre commit hooks to dev-mode golang repos for go fmt and replace rules
- Pinned normal mode git clones to release branch versions
- Added `-b` or `--build` flag to just build and not run
- Renamed `--dev` flag to `--dev-mode`